### PR TITLE
fix(ios): fall back to PATH node when NODE_BINARY is invalid

### DIFF
--- a/superconfig/scripts/generate-config.sh
+++ b/superconfig/scripts/generate-config.sh
@@ -10,6 +10,14 @@ fi
 # Set NODE_BINARY if not already set
 [ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
 
+# If NODE_BINARY is configured but invalid, fall back to PATH lookup.
+if ! type "$NODE_BINARY" >/dev/null 2>&1; then
+  FALLBACK_NODE="$(command -v node || true)"
+  if [ -n "$FALLBACK_NODE" ]; then
+    export NODE_BINARY="$FALLBACK_NODE"
+  fi
+fi
+
 # Check if node is available
 if ! type "$NODE_BINARY" >/dev/null 2>&1; then
   echo "error: Can't find '$NODE_BINARY' to generate Superconfig. " \


### PR DESCRIPTION
## Summary
- make `generate-config.sh` robust when `NODE_BINARY` points to a stale/non-existent path
- if `NODE_BINARY` is invalid, fall back to `command -v node` before failing

## Why
In Xcode builds, `NODE_BINARY` often comes from `.xcode.env.local`. If that absolute path becomes stale (e.g. version-managed Node path changed), Superconfig currently exits even when `node` is otherwise available on PATH.

## Result
iOS build script remains compatible with explicit `NODE_BINARY`, but no longer hard-fails on stale values when a valid `node` can be discovered from PATH.
